### PR TITLE
08-14-2021 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ The plugin should be used together with TukuToi ShortCodes, to ensure full libra
 
 ## Changelog 
 
+### 2.20.3
+* [Fixed] use $.on('event', selector, function()) instead of shorthand $.live('event', function())
+* [Added] Filter to filter the main query after Search and Filter settings are passed to it: tkt_src_fltr_query_args
+* [Fixed] Custom Category Selector for search inputs did not render custom classes even if passed to shortcode
+* [Fixed] Changed query type to be `post_tag` instead of (wrongly) using `tag`
+
 ### 2.19.0
 * [Added] Full AJAX Pagination support with dynamically updating pagination links
 * [Changed] Some code refactor and safety additions

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: TukuToi
 Donate link: https://www.tukutoi.com/
 Tags: search, filter, order, query, classicpress
 Requires at least: 4.9
-Stable tag: 2.19.0
+Stable tag: 2.20.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,6 +14,12 @@ Build Searches and Filters for WordPress Posts, Terms and Users.
 With TukuToi Search & Filter you can build custom Queries and Front End filters, to search thru your Post, Terms or Users.
 
 == Changelog ==
+
+= 2.20.3 =
+* [Fixed] use $.on('event', selector, function()) instead of shorthand $.live('event', function())
+* [Added] Filter to filter the main query after Search and Filter settings are passed to it: tkt_src_fltr_query_args
+* [Fixed] Custom Category Selector for search inputs did not render custom classes even if passed to shortcode
+* [Fixed] Changed query type to be `post_tag` instead of (wrongly) using `tag`
 
 = 2.19.0 =
 * [Added] Full AJAX Pagination support with dynamically updating pagination links

--- a/includes/class-tkt-search-and-filter-declarations.php
+++ b/includes/class-tkt-search-and-filter-declarations.php
@@ -230,37 +230,37 @@ class Tkt_Search_And_Filter_Declarations {
 			'tag'               => array(
 				'label' => esc_html__( 'By Tag Slug', 'tkt-search-and-filter' ),
 				'field' => 'term_slug',
-				'type'  => 'tag',
+				'type'  => 'post_tag',
 			),
 			'tag_id'            => array(
 				'label' => esc_html__( 'By Tag ID', 'tkt-search-and-filter' ),
 				'field' => 'term_id',
-				'type'  => 'tag',
+				'type'  => 'post_tag',
 			),
 			'tag__and'          => array(
 				'label' => esc_html__( 'By Tags in all these Tag IDs (Comma Delimited)', 'tkt-search-and-filter' ),
 				'field' => 'term_id',
-				'type'  => 'tag',
+				'type'  => 'post_tag',
 			),
 			'tag__in'           => array(
 				'label' => esc_html__( 'By Tags in these Tag IDs (Comma Delimited)', 'tkt-search-and-filter' ),
 				'field' => 'term_id',
-				'type'  => 'tag',
+				'type'  => 'post_tag',
 			),
 			'tag__not_in'       => array(
 				'label' => esc_html__( 'By Tags not in any of these Tag IDs (Comma Delimited)', 'tkt-search-and-filter' ),
 				'field' => 'term_id',
-				'type'  => 'tag',
+				'type'  => 'post_tag',
 			),
 			'tag_slug__and'     => array(
 				'label' => esc_html__( 'By Tags in all these Tag Slugs (Comma Delimited)', 'tkt-search-and-filter' ),
 				'field' => 'term_slug',
-				'type'  => 'tag',
+				'type'  => 'post_tag',
 			),
 			'tag_slug__in'      => array(
 				'label' => esc_html__( 'By Tags in some of these Tag Slugs (Comma Delimited)', 'tkt-search-and-filter' ),
 				'field' => 'term_slug',
-				'type'  => 'tag',
+				'type'  => 'post_tag',
 			),
 			's'                 => array(
 				'label' => esc_html__( 'By Search keyword', 'tkt-search-and-filter' ),

--- a/includes/tkt-search-and-filter-fix-worcpress.php
+++ b/includes/tkt-search-and-filter-fix-worcpress.php
@@ -135,7 +135,7 @@ function better_dropdown_users( $args = '' ) {
 		'role'                    => '',
 		'role__in'                => array(),
 		'role__not_in'            => array(),
-		'data_attr'				  => ''
+		'data_attr'               => '',
 	);
 
 	$defaults['selected'] = is_author() ? get_query_var( 'author' ) : 0;
@@ -333,7 +333,7 @@ function better_dropdown_categories( $args = '' ) {
 		'hierarchical'      => 0,
 		'name'              => 'cat',
 		'id'                => '',
-		'class'             => 'postform',
+		'class'             => '',
 		'depth'             => 0,
 		'tab_index'         => 0,
 		'taxonomy'          => 'category',
@@ -343,7 +343,7 @@ function better_dropdown_categories( $args = '' ) {
 		'required'          => false,
 		'multiple'          => '',
 		'allowed_html'      => array(),
-		'data_attr'			=> '',
+		'data_attr'         => '',
 	);
 
 	$defaults['selected'] = ( is_category() ) ? get_query_var( 'cat' ) : 0;
@@ -382,6 +382,7 @@ function better_dropdown_categories( $args = '' ) {
 
 	$name = esc_attr( $r['name'] );
 	$class = esc_attr( $r['class'] );
+
 	$id = $r['id'] ? esc_attr( $r['id'] ) : $name;
 	$required = $r['required'] ? 'required' : '';
 	$multiple = esc_attr( $r['multi'] );

--- a/public/class-tkt-search-and-filter-posts-query.php
+++ b/public/class-tkt-search-and-filter-posts-query.php
@@ -495,6 +495,19 @@ class Tkt_Search_And_Filter_Posts_Query {
 			);
 		}
 
+		/**
+		 * Allow this Query to be filterd.
+		 *
+		 * Other plugins or users might want to alter the Query programmatically.
+		 * For example, to exclude some posts in a Certain Category, you can use this filter.
+		 *
+		 * @since 2.20.3
+		 * @param array $query_args {
+		 *      The query arguments of the WP Query. Default: WP Query Args passed to the Search and Filter instance. Accepts: valid WP Query arguments.
+		 * }
+		 */
+		$query_args = apply_filters( 'tkt_src_fltr_query_args', $query_args );
+
 		$this->query_args = $query_args;
 
 	}

--- a/public/class-tkt-search-and-filter-shortcodes.php
+++ b/public/class-tkt-search-and-filter-shortcodes.php
@@ -346,7 +346,7 @@ class Tkt_Search_And_Filter_Shortcodes {
 
 		// Build our Serach input.
 		$search = '<label for="' . $atts['customid'] . '">' . $atts['placeholder'] . '</label>';
-		$search = '<input type="text" id="' . $atts['customid'] . '" placeholder="' . $atts['placeholder'] . '" name="' . $atts['urlparam'] . '" data-tkt-ajax-src="' . $atts['searchby'] . '">';
+		$search = '<input type="text" id="' . $atts['customid'] . '" placeholder="' . $atts['placeholder'] . '" name="' . $atts['urlparam'] . '" data-tkt-ajax-src="' . $atts['searchby'] . '" class="' . $atts['customclasses'] . '">';
 
 		// Return our Search Input. Already Sanitized.
 		return $search;
@@ -468,7 +468,7 @@ class Tkt_Search_And_Filter_Shortcodes {
 				);
 				break;
 			case 'category':
-			case 'tag':
+			case 'post_tag':
 			case 'taxonomy':
 				$select_form = better_dropdown_categories(
 					array(

--- a/public/js/tkt-search-and-filter-ajax.js
+++ b/public/js/tkt-search-and-filter-ajax.js
@@ -40,7 +40,7 @@
 	 	 * When changing a Select input, update results on the fly.
 	 	 */
 	    $('form[data-tkt-ajax-src-form] select').each(function() {
-	    	$(this).live('change', function() {
+	    	$(this).on('change', function() {
 	    		get_form_search_values();
 		        tkt_get_posts(); //Load Posts
 		    });
@@ -50,7 +50,7 @@
 	 	 * When typing in an input, update results on the fly.
 	 	 */
 	    $('form[data-tkt-ajax-src-form] input').each(function() {
-	    	$(this).live('keyup', function(e) {
+	    	$(this).on('keyup', function(e) {
 		        if( e.keyCode == 27 ) {
 		            $(this).val(''); //If 'escape' was pressed, clear value
 		        }
@@ -62,7 +62,7 @@
 	 	/**
 	 	 * When submitting the search button.
 	 	 */
-	    $('#submit-search').live('click', function(e) {
+	    $('#submit-search').on('click', function(e) {
 
 	        e.preventDefault();
 
@@ -107,7 +107,7 @@
 	    function tkt_paginate() {
 	    	$( '#' + tkt_ajax_params.instance + '_pagination' + ' a').each(function(){
 
-				$(this).live('click', function(e){
+				$(this).on('click', function(e){
 			        e.preventDefault();
 
 			        url = $(this).attr('href'); //Grab the URL destination as a string

--- a/tkt-search-and-filter.php
+++ b/tkt-search-and-filter.php
@@ -15,7 +15,7 @@
  * Plugin Name:       TukuToi Search and Filter
  * Plugin URI:        https://www.tukutoi.com/program/tukutoi-search-and-filter
  * Description:       Build Front End Search and Filters for ClassicPress Posts, Terms and Users.
- * Version:           2.19.0
+ * Version:           2.20.3
  * Author:            TukuToi
  * Author URI:        https://www.tukutoi.com//
  * License:           GPL-2.0+
@@ -34,7 +34,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TKT_SEARCH_AND_FILTER_VERSION', '2.19.0' );
+define( 'TKT_SEARCH_AND_FILTER_VERSION', '2.20.3' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
### 2.20.3
* [Fixed] use $.on('event', selector, function()) instead of shorthand $.live('event', function())
* [Added] Filter to filter the main query after Search and Filter settings are passed to it: tkt_src_fltr_query_args
* [Fixed] Custom Category Selector for search inputs did not render custom classes even if passed to shortcode
* [Fixed] Changed query type to be `post_tag` instead of (wrongly) using `tag`