### PR TITLE
08-16-2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ The plugin should be used together with TukuToi ShortCodes, to ensure full libra
 
 ## Changelog 
 
+### 2.25.2
+* [Added] Filter type (AJAX or Full page Reload) GUI Option
+* [Added] Custom paginate Links function with li_classes, ul_classes, a_classes, current_classes support
+* [Added] New ShortCode to display a Spinner or else value during AJAX operations
+* [Added] Reset functionality with native reset type button on both AJAX and Reload
+* [Fixed] Post Query Args post_type was not validated to array if comma separated, but instead just defaulted to text validation (and sanitization). **Teaching moment**: Luckily all TukuToi Plugins have a standard default fallback for sanitization (sanitize_text_field) or this would have been a securtiy issue, but just a bug
+* [Fixed] Several Select2 instances on same Searh Form are now working
+* [Changed] Several GUI improvements in form of hints and warnings
+* [Changed] Privided method to maybe localise scripts
+
 ### 2.20.3
 * [Fixed] use $.on('event', selector, function()) instead of shorthand $.live('event', function())
 * [Added] Filter to filter the main query after Search and Filter settings are passed to it: tkt_src_fltr_query_args

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: TukuToi
 Donate link: https://www.tukutoi.com/
 Tags: search, filter, order, query, classicpress
 Requires at least: 4.9
-Stable tag: 2.20.3
+Stable tag: 2.25.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,6 +14,16 @@ Build Searches and Filters for WordPress Posts, Terms and Users.
 With TukuToi Search & Filter you can build custom Queries and Front End filters, to search thru your Post, Terms or Users.
 
 == Changelog ==
+
+= 2.25.2 =
+* [Added] Filter type (AJAX or Full page Reload) GUI Option
+* [Added] Custom paginate Links function with li_classes, ul_classes, a_classes, current_classes support
+* [Added] New ShortCode to display a Spinner or else value during AJAX operations
+* [Added] Reset functionality with native reset type button on both AJAX and Reload
+* [Fixed] Post Query Args post_type was not validated to array if comma separated, but instead just defaulted to text validation (and sanitization). **Teaching moment**: Luckily all TukuToi Plugins have a standard default fallback for sanitization (sanitize_text_field) or this would have been a securtiy issue, but just a bug
+* [Fixed] Several Select2 instances on same Searh Form are now working
+* [Changed] Several GUI improvements in form of hints and warnings
+* [Changed] Privided method to maybe localise scripts
 
 = 2.20.3 =
 * [Fixed] use $.on('event', selector, function()) instead of shorthand $.live('event', function())

--- a/admin/class-tkt-search-and-filters-gui.php
+++ b/admin/class-tkt-search-and-filters-gui.php
@@ -187,7 +187,35 @@ class Tkt_Search_And_Filters_Gui {
 		add_filter(
 			'tkt_scs_shortcodes_fieldset_explanation',
 			function( $explanation ) {
-				$explanation = __( 'The Type of Pagination to output' );
+				$explanation = __( 'The Type of Pagination to output (Plain or List)' );
+				return $explanation;
+			}
+		);
+
+	}
+
+	/**
+	 * Create a Select Field set for the ShortCodes Forms Select Type Display Options.
+	 *
+	 * @since 1.4.0
+	 */
+	public function filtertype_options() {
+
+		$filtertype_options = array(
+			'reload'    => 'Full Page Reload',
+			'ajax'      => 'AJAX refresh',
+		);
+
+		foreach ( $filtertype_options as $filtertype_option => $label ) {
+
+			$selected = 'reload' === $filtertype_option ? 'selected' : '';
+			printf( '<option value="%s" ' . esc_attr( $selected ) . '>%s</option>', esc_attr( $filtertype_option ), esc_html( $label ) );
+		}
+
+		add_filter(
+			'tkt_scs_shortcodes_fieldset_explanation',
+			function( $explanation ) {
+				$explanation = __( 'The Type of Search and Filter (AJAX or Full Page Reload)' );
 				return $explanation;
 			}
 		);

--- a/admin/partials/tkt-search-and-filter-pagination-form.php
+++ b/admin/partials/tkt-search-and-filter-pagination-form.php
@@ -23,21 +23,27 @@ $additional_options = new Tkt_Search_And_Filters_Gui( new Tkt_Search_And_Filter_
 ?>
 <form class="tkt-shortcode-form">
 	<?php
-	$this->text_fieldset( 'aria_current', 'The aria-current', 'page', 'What value to use for the aria-current of the current Page' );
+	$this->text_fieldset( 'instance', 'Instance', '', 'The unique instance of Search and Loop this pagination has to control' );
+	$this->text_fieldset( 'pag_arg', 'Pagination Argument', '', 'The URL parameter to use for the paginatio. Can not be \'page\' or \'paged\'' );
 	$this->checkbox_fieldset( 'show_all', 'Show all Pages', '0', 'Whether to show all pages in the pagination or not', '' );
 	$this->text_fieldset( 'end_size', 'End Size', '1', 'How many pagination items to show on start and end of the list' );
 	$this->text_fieldset( 'mid_size', 'Mid Size', '2', 'How many pagination items to show on each side of the current page' );
 	$this->checkbox_fieldset( 'prev_next', 'Show Pre/Next', '1', 'Whether to show the Pre and Next pagination navigation', '' );
 	$this->text_fieldset( 'prev_text', 'Previous Label', 'Pre', 'The label of the Previous Page link' );
 	$this->text_fieldset( 'next_text', 'Next Label', 'Next', 'The label of the Next Page link' );
-	$this->select_fieldset( 'type', 'Query By', '', array( $additional_options, 'pagtype_options' ) );
-	$this->text_fieldset( 'add_args', 'Additional URL parameter', '', 'Additional URL parameters to append. Format \'param_one:value-one,param_two:value-two\'' );
-	$this->text_fieldset( 'add_fragment', 'Trailing Fragment', '', 'You can append a URL fragment at the end of the pagination Link' );
+	$this->select_fieldset( 'type', 'HTML Structure', '', array( $additional_options, 'pagtype_options' ) );
 	$this->text_fieldset( 'before_page_number', 'Before Page Number', '', 'Text to appear before the paginaton Numbere Link Anchor' );
 	$this->text_fieldset( 'after_page_number', 'After Page Number', '', 'Text to appear after the paginaton Numbere Link Anchor' );
-	$this->text_fieldset( 'instance', 'Instance', '', 'The unique instance of Search and Loop this pagination has to control' );
-	$this->text_fieldset( 'customclasses', 'Custom Classes', '', 'Custom Classes to use for the Pagination Buttons' );
-	$this->text_fieldset( 'pag_arg', 'Pagination Argument', '', 'The URL parameter to use for the paginatio. Can not be \'page\' or \'paged\'' );
+	$this->text_fieldset( 'aria_current', 'The aria-current', 'page', 'What value to use for the aria-current of the current Page' );
+	$this->text_fieldset( 'ul_classes', 'Custom \'ul\' Classes', '', 'Custom Classes to use for the \'ul\' Pagination List Element' );
+	$this->text_fieldset( 'li_classes', 'Custom \'li\' Classes', '', 'Custom Classes to use for each Pagination List Item' );
+	$this->text_fieldset( 'a_classes', 'Custom \'a\' Classes', '', 'Custom Classes to use for each Pagination Link (\'a href\') Item' );
+	$this->text_fieldset( 'current_classes', 'aria-current span Classes', '', 'Custom Classes to use for the aria-current span Pagination List' );
+	$this->text_fieldset( 'container', 'Container Type', 'div', 'Type of HTML container to wrap Pagination HTML into' );
+	$this->text_fieldset( 'containerclasses', 'Container Classes', '', 'Custom CSS Classes to use for the Container' );
+
+	$this->text_fieldset( 'add_args', 'Additional URL parameter', '', 'Additional URL parameters to append. Format \'param_one:value-one,param_two:value-two\'' );
+	$this->text_fieldset( 'add_fragment', 'Trailing Fragment', '', 'You can append a URL fragment at the end of the pagination Link' );
 	$this->checkbox_fieldset( 'quotes', 'Quotes', '"', 'What Quotes to use in ShortCodes (Useful when using ShortCodes in other ShortCodes attributes, or in HTML attributes', '' );
 	?>
 </form>

--- a/admin/partials/tkt-search-and-filter-searchtemplate-form.php
+++ b/admin/partials/tkt-search-and-filter-searchtemplate-form.php
@@ -12,6 +12,15 @@
  */
 
 ?>
+<?php
+/**
+ * We need to add some data to the existing TukuToi ShortCode GUI Selector Options.
+ *
+ * @since 2.0.0
+ */
+ require_once plugin_dir_path( dirname( __FILE__ ) ) . 'class-tkt-search-and-filters-gui.php';
+ $additional_options = new Tkt_Search_And_Filters_Gui( new Tkt_Search_And_Filter_Declarations() );
+?>
 <form class="tkt-shortcode-form">
 	
 	<div class="ui-widget tkt-notice-widgets">
@@ -37,6 +46,7 @@
 	</div>
 
 	<?php
+	$this->select_fieldset( 'type', 'Filter Type', 'reload', array( $additional_options, 'filtertype_options' ) );
 	$this->text_fieldset( 'customid', 'Custom ID', '', 'Custom ID to use for the Search Input' );
 	$this->text_fieldset( 'customclasses', 'Custom Classes', '', 'Custom Classes to use for the Search Input' );
 	$this->text_fieldset( 'instance', 'Custom Instance', '', 'Custom instance to bind Filters to specific Loops' );

--- a/admin/partials/tkt-search-and-filter-selectsearch-form.php
+++ b/admin/partials/tkt-search-and-filter-selectsearch-form.php
@@ -25,8 +25,33 @@ $additional_options = new Tkt_Search_And_Filters_Gui( new Tkt_Search_And_Filter_
 	<?php
 	$this->text_fieldset( 'placeholder', 'Placeholder', 'Search', 'What placeholder to show in the Search Input (Or default option)' );
 	$this->text_fieldset( 'urlparam', 'URL Paramter', '', 'URL paramter to use for this Search Input' );
+	?>
+	<div class="ui-widget tkt-notice-widgets">
+		<div class="ui-state-error ui-corner-all tkt-highlight-widget">
+			<p>
+				<span class="ui-icon ui-icon-alert tkt-widget-icon"></span>
+				Do not use any WordPress reserved words for URL parameters</br>
+				Classic examples are <code>author</code>, <code>page</code></br>
+				WordPress tries to rewrite those terms to an archive or pagination permalink
+			</p>
+		</div>
+	</div>
+	<?php
 	$this->select_fieldset( 'searchby', 'Query By', '', array( $additional_options, 'queryvars_options' ) );
 	$this->select_fieldset( 'type', 'Select Type', '', array( $additional_options, 'selecttype_options' ) );
+	?>
+	<div class="ui-widget tkt-notice-widgets">
+		<div class="ui-state-highlight ui-corner-all tkt-highlight-widget">
+			<p>
+				<span class="ui-icon ui-icon-info tkt-widget-icon"></span>
+				Remember - when using Multiselect, you must use the adequate <strong>Query By</strong> argument</br>
+				For example, if you want to search by posts in Multiple Categories, you have to use a Query By argument like:</br>
+				<code>By Categories in all these Category IDs</code> or <code>By Categories in these Category IDs</code></br>
+				Otherwise the results will be none.
+			</p>
+		</div>
+	</div>
+	<?php
 	$this->text_fieldset( 'customid', 'Custom ID', '', 'Custom ID to use for the Search Input' );
 	$this->text_fieldset( 'customclasses', 'Custom Classes', '', 'Custom Classes to use for the Search Input' );
 	$this->checkbox_fieldset( 'quotes', 'Quotes', '"', 'What Quotes to use in ShortCodes (Useful when using ShortCodes in other ShortCodes attributes, or in HTML attributes', '' );

--- a/admin/partials/tkt-search-and-filter-spinner-form.php
+++ b/admin/partials/tkt-search-and-filter-spinner-form.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Provide a admin area view for the plugin
+ *
+ * This file is used to markup the admin-facing aspects of the plugin.
+ *
+ * @link       https://www.tukutoi.com/
+ * @since      1.0.0
+ *
+ * @package    Tkt_Search_And_Filter
+ * @subpackage Tkt_Search_And_Filter/admin/partials
+ */
+
+?>
+<?php
+/**
+ * We need to add some data to the existing TukuToi ShortCode GUI Selector Options.
+ *
+ * @since 2.0.0
+ */
+require_once plugin_dir_path( dirname( __FILE__ ) ) . 'class-tkt-search-and-filters-gui.php';
+$additional_options = new Tkt_Search_And_Filters_Gui( new Tkt_Search_And_Filter_Declarations() );
+?>
+<form class="tkt-shortcode-form">
+	<?php
+	$this->text_fieldset( 'url', 'Asset URL', '', 'URL to the Spinner Asset' );
+	$this->text_fieldset( 'container', 'HTML Container', 'span', 'HTML Container to use as wrapper.' );
+	$this->text_fieldset( 'value', 'Value to append', '', 'A text value to append to the spinner or use instead of the Spinner' );
+	$this->text_fieldset( 'customid', 'Custom ID', '', 'Custom ID to use for the Wrapper HTML element' );
+	$this->text_fieldset( 'customclasses', 'Custom Classes', '', 'Custom Classes to use for the Wrapper HTML element' );
+	$this->checkbox_fieldset( 'quotes', 'Quotes', '"', 'What Quotes to use in ShortCodes (Useful when using ShortCodes in other ShortCodes attributes, or in HTML attributes', '' );
+	?>
+</form>

--- a/admin/partials/tkt-search-and-filter-textsearch-form.php
+++ b/admin/partials/tkt-search-and-filter-textsearch-form.php
@@ -26,7 +26,29 @@ $additional_options = new Tkt_Search_And_Filters_Gui( new Tkt_Search_And_Filter_
 	<?php
 	$this->text_fieldset( 'placeholder', 'Placeholder', 'Search', 'What placeholder to show in the Search Input' );
 	$this->text_fieldset( 'urlparam', 'URL Paramter', '', 'URL paramter to use for this Search Input' );
+	?>
+	<div class="ui-widget tkt-notice-widgets">
+		<div class="ui-state-error ui-corner-all tkt-highlight-widget">
+			<p>
+				<span class="ui-icon ui-icon-alert tkt-widget-icon"></span>
+				Do not use any WordPress reserved words for URL parameters</br>
+				Classic examples are <code>author</code>, <code>page</code></br>
+				WordPress tries to rewrite those terms to an archive or pagination permalink
+			</p>
+		</div>
+	</div>
+	<?php
 	$this->select_fieldset( 'searchby', 'Search Argument', '', array( $additional_options, 'queryvars_options' ) );
+	?>
+	<div class="ui-widget tkt-notice-widgets">
+		<div class="ui-state-highlight ui-corner-all tkt-highlight-widget">
+			<p>
+				<span class="ui-icon ui-icon-info tkt-widget-icon"></span>
+				Remember this is a Text Search Input. It might not make sense to query it by multiple Category IDs, for example ;)
+			</p>
+		</div>
+	</div>
+	<?php
 	$this->text_fieldset( 'customid', 'Custom ID', '', 'Custom ID to use for the Search Input' );
 	$this->text_fieldset( 'customclasses', 'Custom Classes', '', 'Custom Classes to use for the Search Input' );
 	$this->checkbox_fieldset( 'quotes', 'Quotes', '"', 'What Quotes to use in ShortCodes (Useful when using ShortCodes in other ShortCodes attributes, or in HTML attributes', '' );

--- a/includes/class-tkt-search-and-filter-declarations.php
+++ b/includes/class-tkt-search-and-filter-declarations.php
@@ -119,6 +119,11 @@ class Tkt_Search_And_Filter_Declarations {
 				'type'  => 'queryable',
 				'inner' => false,
 			),
+			'spinner' => array(
+				'label' => esc_html__( 'Spinner', 'tkt-search-and-filter' ),
+				'type'  => 'queryable',
+				'inner' => false,
+			),
 		);
 
 		return $shortcodes;
@@ -360,8 +365,8 @@ class Tkt_Search_And_Filter_Declarations {
 		$select_types = array(
 			'single'        => esc_html__( 'Single Select Input', 'tkt-search-and-filter' ),
 			'multiple'      => esc_html__( 'Multiple Select Input', 'tkt-search-and-filter' ),
-			'single_s2'     => esc_html__( 'Single Select2 Input', 'tkt-search-and-filter' ),
-			'multiple_s2'   => esc_html__( 'Multiple Select2 Input', 'tkt-search-and-filter' ),
+			'singleS2'     => esc_html__( 'Single Select2 Input', 'tkt-search-and-filter' ),
+			'multipleS2'   => esc_html__( 'Multiple Select2 Input', 'tkt-search-and-filter' ),
 		);
 
 		$button_types = array(

--- a/includes/class-tkt-search-and-filter.php
+++ b/includes/class-tkt-search-and-filter.php
@@ -308,7 +308,7 @@ class Tkt_Search_And_Filter {
 			 * @since 2.0.0
 			 */
 			require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-tkt-search-and-filter-shortcodes.php';
-			$shortcodes = new Tkt_Search_And_Filter_Shortcodes( $this->plugin_prefix, $this->version, $this->declarations, $query, $sanitizer );
+			$shortcodes = new Tkt_Search_And_Filter_Shortcodes( $this->plugin_prefix, $this->version, $this->declarations, $query, $sanitizer, $plugin_public );
 
 			/**
 			 * The ShortCode Processor making nested and attribute ShortCodes work.

--- a/includes/tkt-search-and-filter-fix-worcpress.php
+++ b/includes/tkt-search-and-filter-fix-worcpress.php
@@ -459,3 +459,242 @@ function better_dropdown_categories( $args = '' ) {
 	}
 	return $output;
 }
+
+/**
+ * ### Start Comment to document Fix ###
+ * Pagination links is a mess. This needs to be urgently refactored and enhqanced.
+ * For now we will add some additional features and fix the biggest mess (they dont even follow WPCS)
+ * ### End Comment to document Fix ###
+ *
+ * Retrieve paginated link for archive post pages.
+ *
+ * Technically, the function can be used to create paginated link list for any
+ * area. The 'base' argument is used to reference the url, which will be used to
+ * create the paginated links. The 'format' argument is then used for replacing
+ * the page number. It is however, most likely and by default, to be used on the
+ * archive post pages.
+ *
+ * The 'type' argument controls format of the returned value. The default is
+ * 'plain', which is just a string with the links separated by a newline
+ * character. The other possible values are either 'array' or 'list'. The
+ * 'array' value will return an array of the paginated link list to offer full
+ * control of display. The 'list' value will place all of the paginated links in
+ * an unordered HTML list.
+ *
+ * The 'total' argument is the total amount of pages and is an integer. The
+ * 'current' argument is the current page number and is also an integer.
+ *
+ * An example of the 'base' argument is "http://example.com/all_posts.php%_%"
+ * and the '%_%' is required. The '%_%' will be replaced by the contents of in
+ * the 'format' argument. An example for the 'format' argument is "?page=%#%"
+ * and the '%#%' is also required. The '%#%' will be replaced with the page
+ * number.
+ *
+ * You can include the previous and next links in the list by setting the
+ * 'prev_next' argument to true, which it is by default. You can set the
+ * previous text, by using the 'prev_text' argument. You can set the next text
+ * by setting the 'next_text' argument.
+ *
+ * If the 'show_all' argument is set to true, then it will show all of the pages
+ * instead of a short list of the pages near the current page. By default, the
+ * 'show_all' is set to false and controlled by the 'end_size' and 'mid_size'
+ * arguments. The 'end_size' argument is how many numbers on either the start
+ * and the end list edges, by default is 1. The 'mid_size' argument is how many
+ * numbers to either side of current page, but not including current page.
+ *
+ * It is possible to add query vars to the link by using the 'add_args' argument
+ * and see add_query_arg() for more information.
+ *
+ * The 'before_page_number' and 'after_page_number' arguments allow users to
+ * augment the links themselves. Typically this might be to add context to the
+ * numbered links so that screen reader users understand what the links are for.
+ * The text strings are added before and after the page number - within the
+ * anchor tag.
+ *
+ * @since WP-2.1.0
+ * @since WP-4.9.0 Added the `aria_current` argument.
+ *
+ * @global WP_Query   $wp_query
+ * @global WP_Rewrite $wp_rewrite
+ *
+ * @param string|array $args {
+ *     Optional. Array or string of arguments for generating paginated links for archives.
+ *
+ *     @type string $base               Base of the paginated url. Default empty.
+ *     @type string $format             Format for the pagination structure. Default empty.
+ *     @type int    $total              The total amount of pages. Default is the value WP_Query's
+ *                                      `max_num_pages` or 1.
+ *     @type int    $current            The current page number. Default is 'paged' query var or 1.
+ *     @type string $aria_current       The value for the aria-current attribute. Possible values are 'page',
+ *                                      'step', 'location', 'date', 'time', 'true', 'false'. Default is 'page'.
+ *     @type bool   $show_all           Whether to show all pages. Default false.
+ *     @type int    $end_size           How many numbers on either the start and the end list edges.
+ *                                      Default 1.
+ *     @type int    $mid_size           How many numbers to either side of the current pages. Default 2.
+ *     @type bool   $prev_next          Whether to include the previous and next links in the list. Default true.
+ *     @type bool   $prev_text          The previous page text. Default '&laquo; Previous'.
+ *     @type bool   $next_text          The next page text. Default 'Next &raquo;'.
+ *     @type string $type               Controls format of the returned value. Possible values are 'plain',
+ *                                      'array' and 'list'. Default is 'plain'.
+ *     @type array  $add_args           An array of query args to add. Default false.
+ *     @type string $add_fragment       A string to append to each link. Default empty.
+ *     @type string $before_page_number A string to appear before the page number. Default empty.
+ *     @type string $after_page_number  A string to append after the page number. Default empty.
+ *
+ *     @type string $li_classes         Classes to be added to each LIST element. Default: empty. Accepts: valid HTML classes.
+ *     @type string $ul_classes         Classes to be added to the UL element. Default: empty. Accepts: valid HTML classes.
+ *     @type string $a_classes          Classes to be added to each a href element. Default: empty. Accepts: valid HTML classes.
+ *     @type string $current_classes    Classes to be added to each span (aria current) element. Default: empty. Accepts: valid HTML classes.
+ * }
+ * @return array|string|void String of page links or array of page links.
+ */
+function better_paginate_links( $args = '' ) {
+	global $wp_query, $wp_rewrite;
+
+	// Setting up default values based on the current URL.
+	$pagenum_link = html_entity_decode( get_pagenum_link() );
+	$url_parts    = explode( '?', $pagenum_link );
+
+	// Get max pages and current page out of the current query, if available.
+	$total   = isset( $wp_query->max_num_pages ) ? $wp_query->max_num_pages : 1;
+	$current = get_query_var( 'paged' ) ? intval( get_query_var( 'paged' ) ) : 1;
+
+	// Append the format placeholder to the base URL.
+	$pagenum_link = trailingslashit( $url_parts[0] ) . '%_%';
+
+	// URL base depends on permalink settings.
+	$format  = $wp_rewrite->using_index_permalinks() && ! strpos( $pagenum_link, 'index.php' ) ? 'index.php/' : '';
+	$format .= $wp_rewrite->using_permalinks() ? user_trailingslashit( $wp_rewrite->pagination_base . '/%#%', 'paged' ) : '?paged=%#%';
+
+	$defaults = array(
+		'base'               => $pagenum_link, // http://example.com/all_posts.php%_% : %_% is replaced by format (below).
+		'format'             => $format, // ?page=%#% : %#% is replaced by the page number
+		'total'              => $total,
+		'current'            => $current,
+		'aria_current'       => 'page',
+		'show_all'           => false,
+		'prev_next'          => true,
+		'prev_text'          => __( '&laquo; Previous' ),
+		'next_text'          => __( 'Next &raquo;' ),
+		'end_size'           => 1,
+		'mid_size'           => 2,
+		'type'               => 'plain',
+		'add_args'           => array(), // array of query args to add.
+		'add_fragment'       => '',
+		'before_page_number' => '',
+		'after_page_number'  => '',
+		'li_classes'         => '',
+		'ul_classes'         => '',
+		'a_classes'          => '',
+		'current_classes'    => '',
+	);
+
+	$args = wp_parse_args( $args, $defaults );
+
+	if ( ! is_array( $args['add_args'] ) ) {
+		$args['add_args'] = array();
+	}
+
+	// Merge additional query vars found in the original URL into 'add_args' array.
+	if ( isset( $url_parts[1] ) ) {
+		// Find the format argument.
+		$format = explode( '?', str_replace( '%_%', $args['format'], $args['base'] ) );
+		$format_query = isset( $format[1] ) ? $format[1] : '';
+		wp_parse_str( $format_query, $format_args );
+
+		// Find the query args of the requested URL.
+		wp_parse_str( $url_parts[1], $url_query_args );
+
+		// Remove the format argument from the array of query arguments, to avoid overwriting custom format.
+		foreach ( $format_args as $format_arg => $format_arg_value ) {
+			unset( $url_query_args[ $format_arg ] );
+		}
+
+		$args['add_args'] = array_merge( $args['add_args'], urlencode_deep( $url_query_args ) );
+	}
+
+	// Who knows what else people pass in $args.
+	$total = (int) $args['total'];
+	if ( $total < 2 ) {
+		return;
+	}
+	$current  = (int) $args['current'];
+	$end_size = (int) $args['end_size']; // Out of bounds?  Make it the default.
+	if ( $end_size < 1 ) {
+		$end_size = 1;
+	}
+	$mid_size = (int) $args['mid_size'];
+	if ( $mid_size < 0 ) {
+		$mid_size = 2;
+	}
+	$add_args = $args['add_args'];
+	$r = '';
+	$page_links = array();
+	$dots = false;
+
+	if ( $args['prev_next'] && $current && 1 < $current ) :
+		$link = str_replace( '%_%', 2 == $current ? '' : $args['format'], $args['base'] );
+		$link = str_replace( '%#%', $current - 1, $link );
+		if ( $add_args ) {
+			$link = add_query_arg( $add_args, $link );
+		}
+		$link .= $args['add_fragment'];
+
+		/**
+		 * Filters the paginated links for the given archive pages.
+		 *
+		 * @since WP-3.0.0
+		 *
+		 * @param string $link The paginated link URL.
+		 */
+		$page_links[] = '<a class="prev page-numbers ' . $args['a_classes'] . '" href="' . esc_url( apply_filters( 'paginate_links', $link ) ) . '">' . $args['prev_text'] . '</a>';
+	endif;
+	for ( $n = 1; $n <= $total; $n++ ) :
+		if ( $n == $current ) :
+			$page_links[] = "<span aria-current='" . esc_attr( $args['aria_current'] ) . "' class='page-numbers current " . $args['current_classes'] . "'> " . $args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number'] . '</span>';
+			$dots = true;
+		else :
+			if ( $args['show_all'] || ( $n <= $end_size || ( $current && $n >= $current - $mid_size && $n <= $current + $mid_size ) || $n > $total - $end_size ) ) :
+				$link = str_replace( '%_%', 1 == $n ? '' : $args['format'], $args['base'] );
+				$link = str_replace( '%#%', $n, $link );
+				if ( $add_args ) {
+					$link = add_query_arg( $add_args, $link );
+				}
+				$link .= $args['add_fragment'];
+
+				/** This filter is documented in wp-includes/general-template.php */
+				$page_links[] = "<a class='page-numbers " . $args['a_classes'] . "' href='" . esc_url( apply_filters( 'paginate_links', $link ) ) . "'>" . $args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number'] . '</a>';
+				$dots = true;
+			elseif ( $dots && ! $args['show_all'] ) :
+				$page_links[] = '<span class="page-numbers dots">' . __( '&hellip;' ) . '</span>';
+				$dots = false;
+			endif;
+		endif;
+	endfor;
+	if ( $args['prev_next'] && $current && $current < $total ) :
+		$link = str_replace( '%_%', $args['format'], $args['base'] );
+		$link = str_replace( '%#%', $current + 1, $link );
+		if ( $add_args ) {
+			$link = add_query_arg( $add_args, $link );
+		}
+		$link .= $args['add_fragment'];
+
+		/** This filter is documented in wp-includes/general-template.php */
+		$page_links[] = '<a class="next page-numbers ' . $args['a_classes'] . '" href="' . esc_url( apply_filters( 'paginate_links', $link ) ) . '">' . $args['next_text'] . '</a>';
+	endif;
+	switch ( $args['type'] ) {
+		case 'array':
+			return $page_links;
+
+		case 'list':
+			$r .= "<ul class='page-numbers " . $args['ul_classes'] . "'>\n\t<li class='" . $args['li_classes'] . "'>";
+			$r .= join( "</li>\n\t<li class='" . $args['li_classes'] . "'>", $page_links );
+			$r .= "</li>\n</ul>\n";
+			break;
+
+		default:
+			$r = join( "\n", $page_links );
+			break;
+	}
+	return $r;
+}

--- a/public/js/tkt-s2-scripts.js
+++ b/public/js/tkt-s2-scripts.js
@@ -1,0 +1,12 @@
+(function( $ ) {
+	'use strict';
+
+	$( document ).ready( function() {
+		$.each( tkt_select2, function( instance, config ) {
+			$( '#' + instance ).select2({
+				placeholder: config.placeholder
+			});
+		});
+	});
+
+})( jQuery );

--- a/public/js/tkt-search-and-filter-ajax.js
+++ b/public/js/tkt-search-and-filter-ajax.js
@@ -9,7 +9,7 @@
 	$( document ).ready( function() {
 		
 		/**
-	 	 * On Document ready load posts, and pagination, if set.
+	 	 * On Document ready load posts, pagination, reset if set.
 	 	 */
 	    tkt_get_posts();
 	    tkt_paginate();
@@ -83,13 +83,13 @@
 
 			});
 
-		 }
+		}
 
 	    /**
 	     * Get all search values of each input by type.
 	     */
 	    function get_search_values_by_type( form ) {	
-	        $('form[data-tkt-ajax-src-form="' + form + '"] input').each(function(){
+	        $('form[data-tkt-ajax-src-form="' + form + '"] input').not(':input[type=hidden]').each(function(){
 
 			    inputs[ $(this).attr('data-tkt-ajax-src') ] = $(this).val();
 

--- a/public/js/tkt-search-and-filter-public.js
+++ b/public/js/tkt-search-and-filter-public.js
@@ -1,39 +1,29 @@
 (function( $ ) {
 	'use strict';
 
-	/**
-	 * All of the code for your public-facing JavaScript source
-	 * should reside in this file.
-	 *
-	 * Note: It has been assumed you will write jQuery code here, so the
-	 * $ function reference has been prepared for usage within the scope
-	 * of this function.
-	 *
-	 * This enables you to define handlers, for when the DOM is ready:
-	 *
-	 * $(function() {
-	 *
-	 * });
-	 *
-	 * When the window is loaded:
-	 *
-	 * $( window ).on('load', function() {
-	 *
-	 * });
-	 *
-	 * ...and/or other possibilities.
-	 *
-	 * Ideally, it is not considered best practice to attach more than a
-	 * single DOM-ready or window-load handler for a particular page.
-	 * Although scripts in the WordPress core, Plugins and Themes may be
-	 * practising this, we should strive to set a better example in our own work.
-	 */
-
 	$( document ).ready( function() {
 
-	    $( '#' + tkt_select2.instance ).select2({
-			placeholder: tkt_select2.placeholder
-		});
+	    /**
+	     * Trigger reset with AJAX
+	     */
+	 	$('[type=reset]').each(function(){
+	 		$(this).off().on('click', function(){ // These little off() are a lifesaver. Without it, you will sum up clicks over clicks and it never stops..
+				$( this ).closest( 'form' ).each(function(){
+	 				$( this ).off().on('reset', function(){
+	 					if( 'undefined' !== typeof tkt_ajax_params){
+	 						// We just need one valid input element to trigger a change, we dont need to trigger all.
+	 						var element = $(this ).find( ':input' ).not(':input[type=reset],:input[type=hidden],:input[type=submit]')[0];
+		 					setTimeout(function(){ 
+		 						$(element).trigger('change');
+		 						return false;
+		 					}, 1, element);
+		 				} else{
+		 					window.location = window.location.href.split("?")[0];
+		 				}
+		 			});
+		 		});
+	 		});
+	 	});
 		
 	});
 

--- a/tkt-search-and-filter.php
+++ b/tkt-search-and-filter.php
@@ -15,7 +15,7 @@
  * Plugin Name:       TukuToi Search and Filter
  * Plugin URI:        https://www.tukutoi.com/program/tukutoi-search-and-filter
  * Description:       Build Front End Search and Filters for ClassicPress Posts, Terms and Users.
- * Version:           2.20.3
+ * Version:           2.25.2
  * Author:            TukuToi
  * Author URI:        https://www.tukutoi.com//
  * License:           GPL-2.0+
@@ -34,7 +34,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'TKT_SEARCH_AND_FILTER_VERSION', '2.20.3' );
+define( 'TKT_SEARCH_AND_FILTER_VERSION', '2.25.2' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
### 2.25.2
* [Added] Filter type (AJAX or Full page Reload) GUI Option
* [Added] Custom paginate Links function with li_classes, ul_classes, a_classes, current_classes support
* [Added] New ShortCode to display a Spinner or else value during AJAX operations
* [Added] Reset functionality with native reset type button on both AJAX and Reload
* [Fixed] Post Query Args post_type was not validated to array if comma separated, but instead just defaulted to text validation (and sanitization). **Teaching moment**: Luckily all TukuToi Plugins have a standard default fallback for sanitization (sanitize_text_field) or this would have been a securtiy issue, but just a bug
* [Fixed] Several Select2 instances on same Searh Form are now working
* [Changed] Several GUI improvements in form of hints and warnings
* [Changed] Privided method to maybe localise scripts